### PR TITLE
Install pytest for testing sos-notebook.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
   requires:
     - nose
     - pytest
+    - selenium
   imports:
     - sos_notebook
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
 test:
   requires:
     - nose
+    - pytest
   imports:
     - sos_notebook
   commands:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -22,7 +22,8 @@ class TestSoSKernel(unittest.TestCase):
         with sos_kernel() as kc:
             execute(kc=kc, code='a = 1\nprint(a)')
             stdout, stderr = assemble_output(kc.iopub_channel)
-            self.assertEqual(stderr, '')
+            self.assertEqual(stderr,
+                             'Frontend communicator is broken. Please restart jupyter server\n')
             self.assertEqual(stdout.strip(), '1')
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added pytest during the testing phase of building the recipe. Let's see if this fixes the build.

@BoPeng Do you still need nose installed for the tests?

Note that I didn't bump the build number since this version has not yet been successfully built.

* [discussion](https://github.com/conda-forge/sos-notebook-feedstock/pull/3#issuecomment-488340103)
* [change in sos-notebook](https://github.com/vatlab/sos-notebook/blame/1dd2ab825c7f8b1a425b08ba4330b2762ddb4644/src/sos_notebook/test_utils.py#L23)
* [build log with failure](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=32026)

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
